### PR TITLE
Persist ride request before review

### DIFF
--- a/src/pages/RideRequestPage.js
+++ b/src/pages/RideRequestPage.js
@@ -11,7 +11,9 @@ import {
 } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { taxiRates } from "../data/taxiRates";
+import { locationCoords } from "../data/locationCoords";
 import { getLocalTaxiRate } from "../lib/getLocalTaxiRate";
+import { createRideRequest } from "../lib/createRideRequest";
 
 export default function RideRequestPage() {
   const navigate = useNavigate();
@@ -45,15 +47,16 @@ export default function RideRequestPage() {
     setLoading(true);
     try {
       const summary = getLocalTaxiRate(pickup, dropoff, passengerCount);
-
-      navigate("/ridesharing/review", {
-        state: {
-          pickup,
-          dropoff,
-          passengerCount,
-          fareSummary: summary,
-        },
+      const rideId = createRideRequest({
+        pickup,
+        dropoff,
+        pickupCoords: locationCoords[pickup],
+        dropoffCoords: locationCoords[dropoff],
+        fare: summary.fare,
+        durationMin: summary.durationMin,
       });
+
+      navigate(`/ridesharing/review/${rideId}`);
     } catch (error) {
       console.error("Failed to preview ride:", error);
       alert("Could not continue to review page.");


### PR DESCRIPTION
## Summary
- Save ride request using `createRideRequest` and navigate to review page with rideId
- Remove state-based navigation in `RideRequestPage`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: ERESOLVE could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68944648f0588329b45b520fddd34fbc