### PR TITLE
refactor: use NavLink in driver bottom nav

### DIFF
--- a/src/components/driver/BottomNav.js
+++ b/src/components/driver/BottomNav.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { NavLink } from "react-router-dom";
 import { FaUsers, FaDollarSign, FaCog } from "react-icons/fa";
 
 export const BottomNav = () => (
@@ -7,15 +8,24 @@ export const BottomNav = () => (
                   border-t border-gray-200 dark:border-gray-700
                   flex justify-around py-2 md:hidden"
   >
-    <NavItem icon={<FaUsers />} label="Requests" href="/driver" />
-    <NavItem icon={<FaDollarSign />} label="Earnings" href="/driver/earnings" />
-    <NavItem icon={<FaCog />} label="Settings" href="/driver/settings" />
+    <NavItem icon={<FaUsers />} label="Requests" to="/driver" />
+    <NavItem icon={<FaDollarSign />} label="Earnings" to="/driver/earnings" />
+    <NavItem icon={<FaCog />} label="Settings" to="/driver/settings" />
   </nav>
 );
 
-const NavItem = ({ icon, label, href }) => (
-  <a href={href} className="flex flex-col items-center text-xs">
+const NavItem = ({ icon, label, to }) => (
+  <NavLink
+    to={to}
+    className={({ isActive }) =>
+      `flex flex-col items-center text-xs ${
+        isActive
+          ? "text-blue-600 dark:text-blue-400"
+          : "text-gray-600 dark:text-gray-300"
+      }`
+    }
+  >
     <span className="text-lg">{icon}</span>
     {label}
-  </a>
+  </NavLink>
 );


### PR DESCRIPTION
## Summary
- use `NavLink` from react-router-dom for driver bottom navigation links
- add active state styling for visual feedback

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: ERESOLVE could not resolve peer dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68944534acd483298f06c7719b4caa9c