### PR TITLE
Persist ride request and navigate using ride ID

### DIFF
--- a/src/pages/RideRequestPage.js
+++ b/src/pages/RideRequestPage.js
@@ -12,6 +12,8 @@ import {
 import { useNavigate } from "react-router-dom";
 import { taxiRates } from "../data/taxiRates";
 import { getLocalTaxiRate } from "../lib/getLocalTaxiRate";
+import { createRideRequest } from "../lib/createRideRequest";
+import { locationCoords } from "../data/locationCoords";
 
 export default function RideRequestPage() {
   const navigate = useNavigate();
@@ -46,14 +48,16 @@ export default function RideRequestPage() {
     try {
       const summary = getLocalTaxiRate(pickup, dropoff, passengerCount);
 
-      navigate("/ridesharing/review", {
-        state: {
-          pickup,
-          dropoff,
-          passengerCount,
-          fareSummary: summary,
-        },
+      const rideId = createRideRequest({
+        pickup,
+        dropoff,
+        pickupCoords: locationCoords[pickup],
+        dropoffCoords: locationCoords[dropoff],
+        fare: summary.fare,
+        durationMin: summary.durationMin,
       });
+
+      navigate(`/ridesharing/review/${rideId}`);
     } catch (error) {
       console.error("Failed to preview ride:", error);
       alert("Could not continue to review page.");


### PR DESCRIPTION
## Summary
- Persist ride request on submission via `createRideRequest`
- Route to review page using returned `rideId`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_689445322a0c83298705426c183cb66a