### PR TITLE
Use rideId param for review navigation

### DIFF
--- a/src/pages/RideRequestPage.js
+++ b/src/pages/RideRequestPage.js
@@ -12,6 +12,8 @@ import {
 import { useNavigate } from "react-router-dom";
 import { taxiRates } from "../data/taxiRates";
 import { getLocalTaxiRate } from "../lib/getLocalTaxiRate";
+import { createRideRequest } from "../lib/createRideRequest";
+import { locationCoords } from "../data/locationCoords";
 
 export default function RideRequestPage() {
   const navigate = useNavigate();
@@ -46,14 +48,16 @@ export default function RideRequestPage() {
     try {
       const summary = getLocalTaxiRate(pickup, dropoff, passengerCount);
 
-      navigate("/ridesharing/review", {
-        state: {
-          pickup,
-          dropoff,
-          passengerCount,
-          fareSummary: summary,
-        },
+      const rideId = createRideRequest({
+        pickup,
+        dropoff,
+        pickupCoords: locationCoords[pickup],
+        dropoffCoords: locationCoords[dropoff],
+        fare: summary.fare,
+        durationMin: summary.durationMin,
       });
+
+      navigate(`/ridesharing/review/${rideId}`);
     } catch (error) {
       console.error("Failed to preview ride:", error);
       alert("Could not continue to review page.");


### PR DESCRIPTION
## Summary
- Save ride using `createRideRequest` in `RideRequestPage`
- Pass ride location coords and navigate to `/ridesharing/review/:rideId`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68944511c6e88329b7772e9356742ffd