### PR TITLE
Add driver earnings page and route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ import Ridesharing from "./pages/Ridesharing";
 import DriverDashboard from "./pages/DriverDashboard";
 import DriverProfilePage from "./pages/DriverProfilePage";
 import DriverRidesPage from "./pages/DriverRidesPage";
+import DriverEarningsPage from "./pages/DriverEarningsPage";
 import DriverSettingsPage from "./pages/DriverSettingsPage";
 import TestMap from "./pages/TestMap";
 import UserRideHistory from "./pages/UserRideHistory";
@@ -109,6 +110,7 @@ function AppShell() {
           <Route index element={<Navigate to="profile" replace />} />
           <Route path="profile" element={<DriverProfilePage />} />
           <Route path="requests" element={<DriverRidesPage />} />
+          <Route path="earnings" element={<DriverEarningsPage />} />
           <Route path="settings" element={<DriverSettingsPage />} />
         </Route>
 

--- a/src/pages/DriverEarningsPage.js
+++ b/src/pages/DriverEarningsPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+export default function DriverEarningsPage() {
+  return (
+    <Box p={3}>
+      <Typography variant="h4" gutterBottom>
+        Earnings
+      </Typography>
+      <Typography variant="body1">
+        Earnings details will appear here.
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder driver earnings page
- wire /driver/earnings route to the new page
- navigation components already link to /driver/earnings

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install react-scripts@5.0.1 --force` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894450318408329a7f9095b2297b407