### PR TITLE
chore: move server libs to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "clsx": "^2.1.1",
+        "express": "^4.19.2",
         "firebase": "^12.0.0",
         "framer-motion": "^12.23.12",
         "html2canvas": "^1.4.1",
@@ -38,13 +39,12 @@
         "react-scripts": "5.0.1",
         "react-toastify": "^11.0.5",
         "recharts": "^3.1.0",
+        "stripe": "^14.0.0",
         "web-vitals": "^3.1.0"
       },
       "devDependencies": {
         "concurrently": "^8.2.2",
         "dotenv": "^16.4.5",
-        "express": "^4.19.2",
-        "stripe": "^14.0.0",
         "typescript": "4.9.5"
       }
     },
@@ -5646,16 +5646,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
@@ -19295,7 +19285,6 @@
       "version": "14.25.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-14.25.0.tgz",
       "integrity": "sha512-wQS3GNMofCXwH8TSje8E1SE8zr6ODiGtHQgPtO95p9Mb4FhKC9jvXR2NUTpZ9ZINlckJcFidCmaTFV4P6vsb9g==",
-      "dev": true,
       "dependencies": {
         "@types/node": ">=8.1.0",
         "qs": "^6.11.0"
@@ -20094,6 +20083,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ajv": "^6.12.6",
     "ajv-keywords": "^3.5.2",
     "clsx": "^2.1.1",
+    "express": "^4.19.2",
     "firebase": "^12.0.0",
     "framer-motion": "^12.23.12",
     "html2canvas": "^1.4.1",
@@ -33,13 +34,12 @@
     "react-scripts": "5.0.1",
     "react-toastify": "^11.0.5",
     "recharts": "^3.1.0",
+    "stripe": "^14.0.0",
     "web-vitals": "^3.1.0"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2",
-    "stripe": "^14.0.0",
     "typescript": "4.9.5"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- move express and stripe from devDependencies to dependencies
- refresh package-lock via npm install

## Testing
- `npm install --package-lock-only --legacy-peer-deps`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689443e25524832988e0fe87cf8e83ef