### PR TITLE
Fix confetti hook cleanup and dynamic import

### DIFF
--- a/src/hooks/useConfetti.js
+++ b/src/hooks/useConfetti.js
@@ -2,14 +2,23 @@ import { useEffect } from 'react';
 
 export function useConfettiOn(trigger) {
   useEffect(() => {
+    let cancelled = false;
+
     if (trigger) {
-      import('canvas-confetti').then((confetti) => {
-        confetti.default({
-          particleCount: 100,
-          spread: 70,
-          origin: { y: 0.6 },
-            });
+      import('canvas-confetti').then(({ default: confetti }) => {
+        if (!cancelled) {
+          confetti({
+            particleCount: 100,
+            spread: 70,
+            origin: { y: 0.6 },
           });
         }
-      }, [trigger]);
+      });
     }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [trigger]);
+}
+


### PR DESCRIPTION
## Summary
- stabilize `useConfettiOn` by structuring dynamic import and cleanup guard

## Testing
- `npx eslint src/hooks/useConfetti.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68944396cb3c83299b45eaea0238644b