### PR TITLE
Add tests for driver modules with Firebase and Stripe mocks

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('App renders without crashing', () => {
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
 });

--- a/src/__tests__/DriverRequestPage.test.js
+++ b/src/__tests__/DriverRequestPage.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import DriverRequestPage from '../pages/DriverRequestPage';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (str) => str }) }));
+
+jest.mock('../lib/getTaxiRouteSummaryFromFirestore');
+import { getTaxiRouteSummaryFromFirestore } from '../lib/getTaxiRouteSummaryFromFirestore';
+
+jest.mock('../components/services/firebase', () => ({
+  auth: {
+    onAuthStateChanged: (cb) => {
+      cb({ email: 'driver@example.com' });
+      return jest.fn();
+    },
+  },
+}));
+
+jest.mock('../components/RoutePreviewMap', () => ({
+  RoutePreviewMap: () => <div data-testid="route-preview-map" />,
+}));
+
+describe('DriverRequestPage', () => {
+  it('shows route summary and user email', async () => {
+    getTaxiRouteSummaryFromFirestore.mockResolvedValue({ fare: 25, durationMin: 15 });
+
+    render(
+      <MemoryRouter initialEntries={["/driver-request?pickup=Adelphi&dropoff=Bolongo&passengers=2"]}>
+        <DriverRequestPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Track Ride')).toBeInTheDocument();
+    expect(screen.getByText('driver@example.com')).toBeInTheDocument();
+
+    await waitFor(() => expect(getTaxiRouteSummaryFromFirestore).toHaveBeenCalled());
+
+    expect(screen.getByText(/ETA:/)).toHaveTextContent('15 min');
+    expect(screen.getByText(/Estimated Fare:/)).toHaveTextContent('$25.00');
+    expect(screen.getByTestId('route-preview-map')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/driverComponents.test.js
+++ b/src/__tests__/driverComponents.test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BottomNav } from '../components/driver/BottomNav';
+import EarningsChart from '../components/driver/EarningsChart';
+import KpiCard from '../components/driver/KpiCard';
+import KpiRow from '../components/driver/KpiRow';
+import LiveMap from '../components/driver/LiveMap';
+import RideCard from '../components/driver/RideCard';
+import { RideQueue } from '../components/driver/RideQueue';
+import Sidebar from '../components/driver/Sidebar';
+
+jest.mock('../hooks/useGoogleMaps', () => jest.fn());
+const useGoogleMaps = require('../hooks/useGoogleMaps');
+useGoogleMaps.mockReturnValue({ isLoaded: false, loadError: false });
+
+jest.mock('../context/ArgonControllerContext', () => ({
+  useArgonController: () => [{ darkMode: false, gtaMode: false }, jest.fn()],
+}));
+
+jest.mock('@react-google-maps/api', () => ({
+  GoogleMap: ({ children }) => <div data-testid="google-map">{children}</div>,
+  Marker: () => <div data-testid="marker" />,
+  Polyline: () => <div data-testid="polyline" />,
+}));
+
+describe('driver components', () => {
+  test('BottomNav renders nav items', () => {
+    render(<BottomNav />);
+    expect(screen.getByText('Requests')).toBeInTheDocument();
+    expect(screen.getByText('Earnings')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  test('EarningsChart renders placeholder', () => {
+    render(<EarningsChart />);
+    expect(screen.getByText(/Earnings Chart/)).toBeInTheDocument();
+  });
+
+  test('KpiCard shows delta styling', () => {
+    const { container: neg } = render(
+      <KpiCard title="Trips" value="10" delta="-5%" />
+    );
+    expect(neg.querySelector('p.text-red-500')).toHaveTextContent('-5%');
+
+    const { container: pos } = render(
+      <KpiCard title="Trips" value="10" delta="5%" />
+    );
+    expect(pos.querySelector('p.text-emerald-500')).toHaveTextContent('5%');
+  });
+
+  test('KpiRow lists three KPIs', () => {
+    render(<KpiRow />);
+    expect(screen.getByText(/Today.?s Rides/)).toBeInTheDocument();
+    expect(screen.getByText(/Earnings/)).toBeInTheDocument();
+    expect(screen.getByText(/Rating/)).toBeInTheDocument();
+  });
+
+  test('LiveMap shows loader when not loaded', () => {
+    render(<LiveMap />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  test('RideCard triggers accept', () => {
+    const ride = {
+      id: '1',
+      pickupText: 'A',
+      dropoffText: 'B',
+      passengers: 2,
+      fare: 10,
+    };
+    const onAccept = jest.fn();
+    const { getByRole, rerender } = render(
+      <RideCard ride={ride} onAccept={onAccept} />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(onAccept).toHaveBeenCalledWith('1');
+
+    rerender(<RideCard ride={ride} onAccept={onAccept} accepting />);
+    expect(getByRole('button')).toHaveTextContent('Accepting');
+  });
+
+  test('RideQueue handles empty and populated lists', () => {
+    const onAccept = jest.fn();
+    const { rerender } = render(<RideQueue rides={[]} onAccept={onAccept} />);
+    expect(screen.getByText(/No pending rides/)).toBeInTheDocument();
+
+    const rides = [
+      { id: '1', pickup: 'A', dropoff: 'B', passengerCount: 2 },
+    ];
+    rerender(<RideQueue rides={rides} onAccept={onAccept} />);
+    fireEvent.click(screen.getByText('A → B'));
+    expect(onAccept).toHaveBeenCalledWith('1');
+  });
+
+  test('Sidebar renders brand and toggle', () => {
+    render(
+      <MemoryRouter initialEntries={['/driver']}>
+        <Sidebar pendingRides={3} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Driver\s*Hub/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Open sidebar/i })).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/getTaxiRouteSummaryFromFirestore.test.js
+++ b/src/__tests__/getTaxiRouteSummaryFromFirestore.test.js
@@ -1,0 +1,58 @@
+import { getTaxiRouteSummaryFromFirestore } from '../lib/getTaxiRouteSummaryFromFirestore';
+
+jest.mock('../lib/firebase', () => ({ db: {} }));
+const mockGetDocs = jest.fn();
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: (...args) => mockGetDocs(...args),
+}));
+
+jest.mock('../data/coords', () => ({
+  locationCoords: {
+    A: { lat: 0, lng: 0 },
+    B: { lat: 0, lng: 1 },
+  },
+}));
+
+describe('getTaxiRouteSummaryFromFirestore', () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset();
+  });
+
+  it('returns null for invalid input', async () => {
+    const result = await getTaxiRouteSummaryFromFirestore('', 'B');
+    expect(result).toBeNull();
+  });
+
+  it('returns firestore result when snapshot found', async () => {
+    mockGetDocs.mockResolvedValue({
+      empty: false,
+      docs: [{ data: () => ({ onePerson: 10, twoPlus: 2, durationMin: 20 }) }],
+    });
+    const result = await getTaxiRouteSummaryFromFirestore('A', 'B', 2);
+    expect(result).toEqual({ fare: 12, durationMin: 20, source: 'firestore' });
+  });
+
+  it('falls back to Haversine when no firestore data', async () => {
+    mockGetDocs.mockResolvedValue({ empty: true, docs: [] });
+    const result = await getTaxiRouteSummaryFromFirestore('A', 'B', 1);
+
+    const R = 6371;
+    const dLat = 0;
+    const dLng = (1 * Math.PI) / 180;
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(0) * Math.cos(0) * Math.sin(dLng / 2) ** 2;
+    const distance = R * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
+    const expectedFare = Math.round((5 + distance * 3) * 100) / 100;
+    const expectedDuration = Math.round((distance / 25) * 60);
+
+    expect(result).toEqual({
+      fare: expectedFare,
+      durationMin: expectedDuration,
+      source: 'fallback',
+    });
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,15 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock Stripe so tests remain deterministic
+jest.mock('@stripe/react-stripe-js', () => ({
+  Elements: ({ children }) => <div>{children}</div>,
+  CardElement: () => <div />,
+  useStripe: () => ({}),
+  useElements: () => ({ getElement: () => ({}) }),
+}));
+
+jest.mock('@stripe/stripe-js', () => ({
+  loadStripe: () => Promise.resolve({}),
+}));


### PR DESCRIPTION
## Summary
- add Stripe mocks to setupTests
- create unit tests for Firestore route summary helper
- add test for DriverRequestPage and driver components

## Testing
- `npm test -- --watchAll=false` (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_689449c67adc832997f156279f73da5f