### PR TITLE
feat: add security middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "react-toastify": "^11.0.5",
     "recharts": "^3.1.0",
     "stripe": "^14.0.0",
-    "web-vitals": "^3.1.0"
+    "web-vitals": "^3.1.0",
+    "cors": "^2.8.5",
+    "helmet": "^7.0.0",
+    "express-rate-limit": "^6.7.0"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",

--- a/server.js
+++ b/server.js
@@ -4,11 +4,22 @@ const logger = require('./logger');
 logger.info('Stripe secret key loaded:', process.env.STRIPE_SECRET_KEY ? '✅ YES' : '❌ MISSING');
 
 const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const app = express();
-const PORT = 5001;
+const PORT = process.env.PORT || 5001;
 
 const BASE_CLIENT_URL = process.env.BASE_CLIENT_URL || 'http://localhost:3000';
+
+app.use(cors({ origin: BASE_CLIENT_URL }));
+app.use(helmet());
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+app.use(limiter);
 
 app.use(express.json());
 


### PR DESCRIPTION
## Summary
- secure API with CORS, Helmet and rate limiting
- read port from `process.env`

## Testing
- `npm install cors helmet express-rate-limit` *(fails: ERESOLVE dependency conflict)*
- `npm install cors helmet express-rate-limit --legacy-peer-deps` *(fails: 403 Forbidden from registry)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68945481d96483299c179e5bd97ac04c