### PR TITLE
Use Firestore realtime queries for driver rides

### DIFF
--- a/src/components/driver/RideQueue.js
+++ b/src/components/driver/RideQueue.js
@@ -1,13 +1,17 @@
 import React from "react";
 import { Typography, List, ListItem, ListItemText } from "@mui/material";
 
-export function RideQueue({ rides = [], onAccept }) {
+export function RideQueue({ rides = [], onAccept, loading = false, dense = false }) {
+  if (loading) {
+    return <Typography>Loading rides...</Typography>;
+  }
+
   if (!rides.length) {
     return <Typography>No pending rides right now.</Typography>;
   }
 
   return (
-    <List>
+    <List dense={dense}>
       {rides.map((ride) => (
         <ListItem
           key={ride.id}

--- a/src/hooks/useDriverRides.js
+++ b/src/hooks/useDriverRides.js
@@ -1,0 +1,77 @@
+import { useState, useEffect } from "react";
+import { db, auth } from "../lib/firebase";
+import { collection, query, where, onSnapshot } from "firebase/firestore";
+
+export default function useDriverRides() {
+  const [pendingRides, setPendingRides] = useState([]);
+  const [activeRides, setActiveRides] = useState([]);
+  const [completedRides, setCompletedRides] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    let pendingLoaded = false;
+    let activeLoaded = !uid;
+    let completedLoaded = !uid;
+
+    const checkLoaded = () => {
+      if (pendingLoaded && activeLoaded && completedLoaded) {
+        setLoading(false);
+      }
+    };
+
+    const pendingQuery = query(
+      collection(db, "rideRequests"),
+      where("status", "==", "pending")
+    );
+    const unsubPending = onSnapshot(pendingQuery, (snapshot) => {
+      setPendingRides(
+        snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+      );
+      pendingLoaded = true;
+      checkLoaded();
+    });
+
+    let unsubActive = () => {};
+    let unsubCompleted = () => {};
+
+    if (uid) {
+      const activeQuery = query(
+        collection(db, "rideRequests"),
+        where("driverId", "==", uid),
+        where("status", "in", ["accepted", "en-route"])
+      );
+      unsubActive = onSnapshot(activeQuery, (snapshot) => {
+        setActiveRides(
+          snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+        );
+        activeLoaded = true;
+        checkLoaded();
+      });
+
+      const completedQuery = query(
+        collection(db, "rideRequests"),
+        where("driverId", "==", uid),
+        where("status", "==", "completed")
+      );
+      unsubCompleted = onSnapshot(completedQuery, (snapshot) => {
+        setCompletedRides(
+          snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+        );
+        completedLoaded = true;
+        checkLoaded();
+      });
+    } else {
+      setActiveRides([]);
+      setCompletedRides([]);
+    }
+
+    return () => {
+      unsubPending();
+      unsubActive();
+      unsubCompleted();
+    };
+  }, []);
+
+  return { pendingRides, activeRides, completedRides, loading };
+}


### PR DESCRIPTION
## Summary
- add `useDriverRides` hook leveraging Firestore `onSnapshot` to track pending, active and completed rides in realtime
- replace placeholder ride arrays in dashboard and rides page with live queries and loading states
- enhance `RideQueue` component to display loading and support dense lists

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689454926e408329ae4d3b13becb93e6