### PR TITLE
chore: guard stripe secret key

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,10 +1,14 @@
 require('dotenv').config();
 const logger = require('./logger');
-
-logger.info('Stripe secret key loaded:', process.env.STRIPE_SECRET_KEY ? '✅ YES' : '❌ MISSING');
-
 const express = require('express');
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+if (!stripeSecretKey) {
+  logger.error('STRIPE_SECRET_KEY environment variable is missing');
+  process.exit(1);
+}
+
+const stripe = require('stripe')(stripeSecretKey);
 const app = express();
 const PORT = 5001;
 


### PR DESCRIPTION
## Summary
- remove logging that exposed Stripe secret key presence
- fail fast when STRIPE_SECRET_KEY is missing before initializing Stripe client

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68945485c4fc8329a73a3b0229920bb0