### PR TITLE
feat: allow cancelling rides

### DIFF
--- a/src/pages/RideConfirmedPage.js
+++ b/src/pages/RideConfirmedPage.js
@@ -32,6 +32,20 @@ export default function RideConfirmedPage() {
   const [ride, setRide] = useState(() => location.state?.ride || readRide(rideId));
   const [paying, setPaying] = useState(false);
 
+  /* --------------------------- Cancel ride handler --------------------------- */
+  const handleCancelRide = () => {
+    try {
+      const store = JSON.parse(localStorage.getItem('rideRequests') || '{}');
+      if (store[rideId]) {
+        store[rideId] = { ...store[rideId], status: 'cancelled' };
+        localStorage.setItem('rideRequests', JSON.stringify(store));
+      }
+    } catch (err) {
+      logger.warn('Failed to cancel ride', err);
+    }
+    navigate('/home');
+  };
+
   /* keep state in sync if another tab updates localStorage */
   useEffect(() => {
     const sync = (e) => {
@@ -121,6 +135,14 @@ export default function RideConfirmedPage() {
 
         <Button variant="outlined" onClick={() => navigate('/home')}>
           Return Home
+        </Button>
+
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={handleCancelRide}
+        >
+          Cancel Ride
         </Button>
 
         <Button

--- a/src/pages/RideTrackingPage.js
+++ b/src/pages/RideTrackingPage.js
@@ -43,6 +43,16 @@ export default function RideTrackingPage() {
     );
   }
 
+  const { status = 'requested' } = ride;
+
+  if (status === 'cancelled') {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white">
+        <p className="text-xl font-medium">{t('Ride cancelled')} 😢</p>
+      </main>
+    );
+  }
+
   const {
     pickup,
     dropoff,
@@ -50,7 +60,6 @@ export default function RideTrackingPage() {
     dropoffCoords,
     fare,
     durationMin,
-    status = 'requested',
   } = ride;
 
   return (


### PR DESCRIPTION
## Summary
- add cancel handler/button to ride confirmation page
- show message when tracking a cancelled ride

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689455f103dc8329924a1a75cd8b301b