### PR TITLE
feat: store rides in firestore

### DIFF
--- a/src/lib/createRideRequest.js
+++ b/src/lib/createRideRequest.js
@@ -1,33 +1,30 @@
 // src/lib/createRideRequest.js
-export function createRideRequest({
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from './firebase';
+
+export async function createRideRequest({
   pickup,
   dropoff,
   pickupCoords,
   dropoffCoords,
   fare,
   durationMin,
+  passengerCount = 1,
+  ownerId,
 }) {
-  // ► simple unique id
-  const rideId =
-    Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
-
   const newRide = {
-    rideId,
     pickup,
     dropoff,
     pickupCoords,
     dropoffCoords,
     fare,
     durationMin,
+    passengerCount,
+    ownerId: ownerId || null,
     status: 'requested',
-    createdAt: Date.now(),
+    createdAt: serverTimestamp(),
   };
 
-  // store in localStorage (as an object keyed by rideId)
-  const storeKey = 'rideRequests';
-  const existing = JSON.parse(localStorage.getItem(storeKey) || '{}');
-  existing[rideId] = newRide;
-  localStorage.setItem(storeKey, JSON.stringify(existing));
-
-  return rideId;
+  const docRef = await addDoc(collection(db, 'rides'), newRide);
+  return docRef.id;
 }

--- a/src/lib/rideService.js
+++ b/src/lib/rideService.js
@@ -1,0 +1,63 @@
+import { collection, doc, getDoc, onSnapshot, updateDoc, query, where, getDocs } from 'firebase/firestore';
+import { db } from './firebase';
+
+const ridesCol = collection(db, 'rides');
+
+/**
+ * Fetch a single ride document once. Returns `null` if not found.
+ */
+export async function fetchRide(rideId) {
+  const snap = await getDoc(doc(ridesCol, rideId));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+/**
+ * Subscribe to real-time updates for a ride.
+ * @param {string} rideId
+ * @param {(ride: object|null) => void} callback
+ * @returns {() => void} unsubscribe function
+ */
+export function subscribeToRide(rideId, callback) {
+  return onSnapshot(doc(ridesCol, rideId), (snap) => {
+    callback(snap.exists() ? { id: snap.id, ...snap.data() } : null);
+  });
+}
+
+/**
+ * Update fields on a ride document.
+ */
+export async function updateRide(rideId, data) {
+  await updateDoc(doc(ridesCol, rideId), data);
+}
+
+/**
+ * Fetch rides matching one or more statuses.
+ * @param {string|string[]} statuses
+ */
+export async function fetchRidesByStatus(statuses) {
+  const arr = Array.isArray(statuses) ? statuses : [statuses];
+  const q = query(
+    ridesCol,
+    where('status', arr.length > 1 ? 'in' : '==', arr.length > 1 ? arr : arr[0])
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+/**
+ * Subscribe to rides by status.
+ * @param {string|string[]} statuses
+ * @param {(rides: object[]) => void} callback
+ * @returns {() => void}
+ */
+export function subscribeToRidesByStatus(statuses, callback) {
+  const arr = Array.isArray(statuses) ? statuses : [statuses];
+  const q = query(
+    ridesCol,
+    where('status', arr.length > 1 ? 'in' : '==', arr.length > 1 ? arr : arr[0])
+  );
+  return onSnapshot(q, (snap) => {
+    callback(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+  });
+}
+

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -14,6 +14,7 @@ import { useNavigate } from 'react-router-dom';
 import { taxiRates, allLocations } from '../data/taxiRates';
 import { getLocalTaxiRate } from '../lib/getLocalTaxiRate';
 import { createRideRequest } from '../lib/createRideRequest';
+import { auth } from '../lib/firebase';
 import HomeMap from '../components/HomeMap';
 import { locationCoords } from '../data/locationCoords';
 import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
@@ -43,20 +44,22 @@ export default function HomePage() {
     setFareInfo(summary);
   };
 
-  const handleBookRide = () => {
+  const handleBookRide = async () => {
     if (!fareInfo) {
       alert('Please estimate your fare first.');
       return;
     }
     setBookingBusy(true);
     try {
-      const rideId = createRideRequest({
+      const rideId = await createRideRequest({
         pickup,
         dropoff,
         pickupCoords: locationCoords[pickup],
         dropoffCoords: locationCoords[dropoff],
         fare: fareInfo.fare,
         durationMin: fareInfo.durationMin,
+        passengerCount: 1,
+        ownerId: auth.currentUser ? auth.currentUser.uid : undefined,
       });
       navigate(`/ridesharing/review/${rideId}`);
     } catch (err) {

--- a/src/pages/RideRequestPage.js
+++ b/src/pages/RideRequestPage.js
@@ -1,24 +1,15 @@
 // src/pages/RideRequestPage.js
 
 import React, { useState } from "react";
-import {
-  Box,
-  Button,
-  MenuItem,
-  TextField,
-  Typography,
-  Paper,
-} from "@mui/material";
+import { Box, Button, MenuItem, TextField, Typography, Paper } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { taxiRates } from "../data/taxiRates";
 import { locationCoords } from "../data/locationCoords";
 import { getLocalTaxiRate } from "../lib/getLocalTaxiRate";
 import { createRideRequest } from "../lib/createRideRequest";
-import { locationCoords } from "../data/locationCoords";
+import { auth } from "../lib/firebase";
 
 import logger from "../logger";
-
-import { createRideRequest } from "../lib/createRideRequest";
 
 
 export default function RideRequestPage() {
@@ -44,7 +35,7 @@ export default function RideRequestPage() {
     }
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!pickup || !dropoff || pickup === dropoff) {
       alert("Please select valid locations.");
       return;
@@ -54,13 +45,15 @@ export default function RideRequestPage() {
     try {
       const summary = getLocalTaxiRate(pickup, dropoff, passengerCount);
 
-      const rideId = createRideRequest({
+      const rideId = await createRideRequest({
         pickup,
         dropoff,
         pickupCoords: locationCoords[pickup],
         dropoffCoords: locationCoords[dropoff],
         fare: summary.fare,
         durationMin: summary.durationMin,
+        passengerCount,
+        ownerId: auth.currentUser ? auth.currentUser.uid : undefined,
       });
 
       navigate(`/ridesharing/review/${rideId}`);

--- a/src/pages/RideReviewPage.js
+++ b/src/pages/RideReviewPage.js
@@ -1,38 +1,19 @@
 // src/pages/RideReviewPage.js
 import React, { useEffect, useState } from 'react';
-import {
-  Box,
-  Button,
-  Paper,
-  Typography,
-  Grid,
-} from '@mui/material';
+import { Box, Button, Paper, Typography, Grid } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
 import MyMapView from '../components/RoutePreviewMap';
-
-/* helper -------------------------------------------------------------- */
-function readRide(id) {
-  try {
-    return JSON.parse(localStorage.getItem('rideRequests') || '{}')[id] ?? null;
-  } catch {
-    return null; // corrupt JSON
-  }
-}
+import { subscribeToRide, updateRide } from '../lib/rideService';
 
 export default function RideReviewPage() {
   const { rideId } = useParams();
   const navigate   = useNavigate();
 
-  /* keep the ride in state so we can react to live storage updates */
-  const [ride, setRide] = useState(() => readRide(rideId));
+  const [ride, setRide] = useState(null);
 
-  /* listen for changes from other tabs or the driver dashboard */
   useEffect(() => {
-    const onStorage = (e) => {
-      if (e.key === 'rideRequests') setRide(readRide(rideId));
-    };
-    window.addEventListener('storage', onStorage);
-    return () => window.removeEventListener('storage', onStorage);
+    const unsubscribe = subscribeToRide(rideId, setRide);
+    return unsubscribe;
   }, [rideId]);
 
   /* early exit if the ride vanished (bad id, cleared storage, …) */
@@ -60,21 +41,13 @@ export default function RideReviewPage() {
   } = ride;
 
   /* confirm handler: mark status + jump to tracking page */
-  const handleConfirm = () => {
-  /* 1 – mark as confirmed in storage */
-  const storeRaw = localStorage.getItem('rideRequests') || '{}';
-  const store    = JSON.parse(storeRaw);
-  if (store[rideId]) {
-    store[rideId] = { ...store[rideId], status: 'confirmed' };
-    localStorage.setItem('rideRequests', JSON.stringify(store));
-  }
-
-  /* 2 – navigate to the confirmation page, passing the ride object */
-  navigate(
-    `/ridesharing/confirmed/${rideId}`,
-    { state: { ride: { ...store[rideId], id: rideId } }, replace: true }
-  );
-};
+  const handleConfirm = async () => {
+    await updateRide(rideId, { status: 'confirmed' });
+    navigate(
+      `/ridesharing/confirmed/${rideId}`,
+      { state: { ride: { ...ride, status: 'confirmed', id: rideId } }, replace: true }
+    );
+  };
 
   /* ─── render ────────────────────────────────────────────────────── */
   return (

--- a/src/pages/RideTrackingPage.js
+++ b/src/pages/RideTrackingPage.js
@@ -4,34 +4,16 @@ import { FaCar } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import MyMapView from '../components/RoutePreviewMap';
-
-/**
- * Reads a single ride object from localStorage, returns `null` if missing.
- */
-function getRideById(id) {
-  try {
-    const store = JSON.parse(localStorage.getItem('rideRequests') || '{}');
-    return store[id] ?? null;
-  } catch {
-    /* corrupt or empty storage */
-    return null;
-  }
-}
+import { subscribeToRide } from '../lib/rideService';
 
 export default function RideTrackingPage() {
   const { t } = useTranslation();
   const { rideId } = useParams();              // ← /ridesharing/track/:rideId
-  const [ride, setRide] = useState(() => getRideById(rideId));
+  const [ride, setRide] = useState(null);
 
-  /* listen for live updates from other tabs or the driver dashboard */
   useEffect(() => {
-    function handleStorage(e) {
-      if (e.key === 'rideRequests') {
-        setRide(getRideById(rideId));
-      }
-    }
-    window.addEventListener('storage', handleStorage);
-    return () => window.removeEventListener('storage', handleStorage);
+    const unsubscribe = subscribeToRide(rideId, setRide);
+    return unsubscribe;
   }, [rideId]);
 
   /* if nothing was found show a friendly message */


### PR DESCRIPTION
## Summary
- persist ride requests to a Firestore `rides` collection
- add a rideService helper for fetching and subscribing to rides
- load ride data from Firestore on rider and driver pages

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68945600ba348329a1fc6be948e9e50f