### PR TITLE
refactor: centralize location coordinates

### DIFF
--- a/src/__tests__/getTaxiRouteSummaryFromFirestore.test.js
+++ b/src/__tests__/getTaxiRouteSummaryFromFirestore.test.js
@@ -9,7 +9,7 @@ jest.mock('firebase/firestore', () => ({
   getDocs: (...args) => mockGetDocs(...args),
 }));
 
-jest.mock('../data/coords', () => ({
+jest.mock('../data/locationCoords', () => ({
   locationCoords: {
     A: { lat: 0, lng: 0 },
     B: { lat: 0, lng: 1 },

--- a/src/lib/getTaxiRouteSummaryFromFirestore.js
+++ b/src/lib/getTaxiRouteSummaryFromFirestore.js
@@ -5,12 +5,8 @@ import {
   getDocs,
 } from "firebase/firestore";
 
-import { db } from "../lib/firebase";
-import { locationCoords } from "../data/locationCoords";
-
-
 import { db } from "./firebase";
-import { locationCoords } from "../data/coords";
+import { locationCoords } from "../data/locationCoords";
 import logger from "../logger";
 
 

--- a/src/pages/RideRequestPage.js
+++ b/src/pages/RideRequestPage.js
@@ -14,11 +14,7 @@ import { taxiRates } from "../data/taxiRates";
 import { locationCoords } from "../data/locationCoords";
 import { getLocalTaxiRate } from "../lib/getLocalTaxiRate";
 import { createRideRequest } from "../lib/createRideRequest";
-import { locationCoords } from "../data/locationCoords";
-
 import logger from "../logger";
-
-import { createRideRequest } from "../lib/createRideRequest";
 
 
 export default function RideRequestPage() {


### PR DESCRIPTION
## Summary
- remove duplicate coordinate imports
- ensure tests and pages import from single locationCoords map

## Testing
- `CI=true npm test` *(fails: react-scripts: not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6894565d0f648329935ce6c241dfb0c1