### PR TITLE
refactor: streamline server imports

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,9 @@
 require('dotenv').config();
 const logger = require('./logger');
 const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
 if (!stripeSecretKey) {
@@ -8,13 +11,7 @@ if (!stripeSecretKey) {
   process.exit(1);
 }
 
-
 const stripe = require('stripe')(stripeSecretKey);
-const express = require('express');
-const cors = require('cors');
-const helmet = require('helmet');
-const rateLimit = require('express-rate-limit');
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 
 const app = express();
 const PORT = process.env.PORT || 5001;
@@ -31,7 +28,7 @@ try {
   }
   db = admin.firestore();
 } catch (err) {
-  console.warn('⚠️  Firebase Admin not initialised:', err.message);
+  logger.warn('⚠️  Firebase Admin not initialised:', err.message);
 }
 
 app.use(cors({ origin: BASE_CLIENT_URL }));


### PR DESCRIPTION
## Summary
- remove duplicate express/stripe imports and centralize Stripe key validation
- replace console warning with logger warning for Firestore initialization

## Testing
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68965e41f63483299c67336a7851019d