### PR TITLE
chore: ignore local development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,5 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local development artifacts
-BROWSER=none
-codespaces-react@0.1.0
+/BROWSER=none
+/codespaces-react@0.1.0


### PR DESCRIPTION
## Summary
- ignore stray local files `BROWSER=none` and `codespaces-react@0.1.0`

## Testing
- `CI=true npm test` *(fails: sh: 1: react-scripts: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6894568b782483298f7dc63951a09c6b