### PR TITLE
Add auth listener cleanup

### DIFF
--- a/src/__tests__/DriverRequestPage.test.js
+++ b/src/__tests__/DriverRequestPage.test.js
@@ -8,20 +8,39 @@ jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (str) => str }) 
 jest.mock('../lib/getTaxiRouteSummaryFromFirestore');
 import { getTaxiRouteSummaryFromFirestore } from '../lib/getTaxiRouteSummaryFromFirestore';
 
-jest.mock('../components/services/firebase', () => ({
-  auth: {
-    onAuthStateChanged: (cb) => {
-      cb({ email: 'driver@example.com' });
-      return jest.fn();
-    },
-  },
-}));
+jest.mock('../lib/firebase', () => {
+  const listeners = [];
+  const mockOnAuthStateChanged = jest.fn((cb) => {
+    listeners.push(cb);
+    cb({ email: 'driver@example.com' });
+    return () => {
+      const index = listeners.indexOf(cb);
+      if (index > -1) listeners.splice(index, 1);
+    };
+  });
+  return {
+    auth: { onAuthStateChanged: mockOnAuthStateChanged },
+    __esModule: true,
+    __listeners: listeners,
+    __mockOnAuthStateChanged: mockOnAuthStateChanged,
+  };
+});
+
+import {
+  __listeners as listeners,
+  __mockOnAuthStateChanged as mockOnAuthStateChanged,
+} from '../lib/firebase';
 
 jest.mock('../components/RoutePreviewMap', () => ({
   RoutePreviewMap: () => <div data-testid="route-preview-map" />,
 }));
 
 describe('DriverRequestPage', () => {
+  beforeEach(() => {
+    listeners.length = 0;
+    mockOnAuthStateChanged.mockClear();
+  });
+
   it('shows route summary and user email', async () => {
     getTaxiRouteSummaryFromFirestore.mockResolvedValue({ fare: 25, durationMin: 15 });
 
@@ -39,5 +58,26 @@ describe('DriverRequestPage', () => {
     expect(screen.getByText(/ETA:/)).toHaveTextContent('15 min');
     expect(screen.getByText(/Estimated Fare:/)).toHaveTextContent('$25.00');
     expect(screen.getByTestId('route-preview-map')).toBeInTheDocument();
+  });
+
+  it('cleans up auth listener on navigation', () => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/driver-request?pickup=Adelphi&dropoff=Bolongo&passengers=2"]}>
+        <DriverRequestPage />
+      </MemoryRouter>
+    );
+
+    expect(listeners).toHaveLength(1);
+    unmount();
+    expect(listeners).toHaveLength(0);
+
+    render(
+      <MemoryRouter initialEntries={["/driver-request?pickup=Adelphi&dropoff=Bolongo&passengers=2"]}>
+        <DriverRequestPage />
+      </MemoryRouter>
+    );
+
+    expect(listeners).toHaveLength(1);
+    expect(mockOnAuthStateChanged).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pages/DriverRequestPage.js
+++ b/src/pages/DriverRequestPage.js
@@ -21,7 +21,10 @@ const Ridesharing = () => {
   const [duration, setDuration] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => auth.onAuthStateChanged(setUser), []);
+  useEffect(() => {
+    const unsub = auth.onAuthStateChanged(setUser);
+    return () => unsub();
+  }, []);
 
   const pickupCoords = locationCoords[pickupLocation];
   const dropoffCoords = locationCoords[dropoffLocation];


### PR DESCRIPTION
## Summary
- prevent duplicate auth listeners by unsubscribing in DriverRequestPage
- test DriverRequestPage to confirm auth listener cleanup on navigation

## Testing
- `CI=true npm test --silent` *(fails: react-scripts: not found)*
- `npm install react-scripts@5.0.1 --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68945676fa8883299ffe1ebc97c30665