### PR TITLE
refactor: centralize mapbox token configuration

### DIFF
--- a/src/components/HomeMap.js
+++ b/src/components/HomeMap.js
@@ -1,9 +1,7 @@
 // src/components/HomeMap.js
 import React, { useRef, useEffect } from 'react';
-import mapboxgl from 'mapbox-gl';
+import mapboxgl from '../lib/mapbox';
 import 'mapbox-gl/dist/mapbox-gl.css';
-
-mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN;
 
 export default function HomeMap({ pickupCoords, dropoffCoords }) {
   const mapRef = useRef(null);

--- a/src/components/TrackMap.js
+++ b/src/components/TrackMap.js
@@ -1,8 +1,6 @@
 import React, { useRef, useEffect } from 'react';
-import mapboxgl from 'mapbox-gl';
+import mapboxgl from '../lib/mapbox';
 import 'mapbox-gl/dist/mapbox-gl.css';
-
-mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
 
 export default function TrackMap() {
   const mapRef = useRef(null);

--- a/src/lib/mapbox.js
+++ b/src/lib/mapbox.js
@@ -1,0 +1,11 @@
+import mapboxgl from 'mapbox-gl';
+
+const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
+
+if (!MAPBOX_TOKEN) {
+  console.warn('Mapbox token is missing. Please set REACT_APP_MAPBOX_TOKEN.');
+}
+
+mapboxgl.accessToken = MAPBOX_TOKEN;
+
+export default mapboxgl;


### PR DESCRIPTION
## Summary
- centralize Mapbox token handling in `src/lib/mapbox.js`
- switch Mapbox components to shared config

## Testing
- `npm test --silent -- --watchAll=false` (fails: react-scripts not found)
- `npm install` (fails: dependency conflict, Typescript peer mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68945671ead883299dd4f66d5e1357af