### PR TITLE
Fix confetti hook import and handle failures

### DIFF
--- a/src/hooks/useConfetti.js
+++ b/src/hooks/useConfetti.js
@@ -5,15 +5,19 @@ export function useConfettiOn(trigger) {
     let cancelled = false;
 
     if (trigger) {
-      import('canvas-confetti').then(({ default: confetti }) => {
-        if (!cancelled) {
-          confetti({
-            particleCount: 100,
-            spread: 70,
-            origin: { y: 0.6 },
-          });
-        }
-      });
+      import('canvas-confetti')
+        .then((confetti) => {
+          if (!cancelled) {
+            confetti.default({
+              particleCount: 100,
+              spread: 70,
+              origin: { y: 0.6 },
+            });
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to load canvas-confetti', err);
+        });
     }
 
     return () => {


### PR DESCRIPTION
## Summary
- use default-export call from `canvas-confetti`
- add graceful `.catch` for failed imports

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6894566d9bf88329a1e0d648df11d066