### PR TITLE
refactor: centralize firebase init

### DIFF
--- a/src/__tests__/DriverRequestPage.test.js
+++ b/src/__tests__/DriverRequestPage.test.js
@@ -8,7 +8,7 @@ jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (str) => str }) 
 jest.mock('../lib/getTaxiRouteSummaryFromFirestore');
 import { getTaxiRouteSummaryFromFirestore } from '../lib/getTaxiRouteSummaryFromFirestore';
 
-jest.mock('../components/services/firebase', () => ({
+jest.mock('../lib/firebase', () => ({
   auth: {
     onAuthStateChanged: (cb) => {
       cb({ email: 'driver@example.com' });

--- a/src/lib/getTaxiRouteSummaryFromFirestore.js
+++ b/src/lib/getTaxiRouteSummaryFromFirestore.js
@@ -5,12 +5,8 @@ import {
   getDocs,
 } from "firebase/firestore";
 
-import { db } from "../lib/firebase";
-import { locationCoords } from "../data/locationCoords";
-
-
 import { db } from "./firebase";
-import { locationCoords } from "../data/coords";
+import { locationCoords } from "../data/locationCoords";
 import logger from "../logger";
 
 


### PR DESCRIPTION
## Summary
- consolidate Firebase init to a single module
- update Firestore helper and tests to use centralized Firebase

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894566235748329960c824fc1d7efbb