### PR TITLE
Persist theme preferences

### DIFF
--- a/src/context/ArgonControllerContext.js
+++ b/src/context/ArgonControllerContext.js
@@ -1,13 +1,31 @@
 import React, { createContext, useContext, useReducer } from "react";
 
 /* ---------- state ---------- */
-const initialState = { darkMode: false, gtaMode: false };
+const storeKey = "argonPrefs";
+const baseState = { darkMode: false, gtaMode: false };
+
+function init(initial) {
+  try {
+    return JSON.parse(localStorage.getItem(storeKey)) || initial;
+  } catch {
+    return initial;
+  }
+}
 
 function reducer(state, action) {
   switch (action.type) {
-    case "TOGGLE_DARK": return { ...state, darkMode: !state.darkMode };
-    case "TOGGLE_GTA":  return { ...state, gtaMode:  !state.gtaMode };
-    default:            return state;
+    case "TOGGLE_DARK": {
+      const next = { ...state, darkMode: !state.darkMode };
+      try { localStorage.setItem(storeKey, JSON.stringify(next)); } catch {}
+      return next;
+    }
+    case "TOGGLE_GTA": {
+      const next = { ...state, gtaMode: !state.gtaMode };
+      try { localStorage.setItem(storeKey, JSON.stringify(next)); } catch {}
+      return next;
+    }
+    default:
+      return state;
   }
 }
 
@@ -16,7 +34,7 @@ const ArgonControllerContext = createContext();
 
 /* ---------- provider ---------- */
 export function ArgonControllerProvider({ children }) {
-  const value = useReducer(reducer, initialState);
+  const value = useReducer(reducer, baseState, init);
   return (
     <ArgonControllerContext.Provider value={value}>
       {children}


### PR DESCRIPTION
## Summary
- initialize ArgonControllerContext state from `localStorage`
- persist `darkMode` and `gtaMode` toggles back to `localStorage`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_689455e42d9483299d96b420e5793b19