### PR TITLE
feat: add reusable snackbar notification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,7 @@ import DriverEarningsPage from "./pages/DriverEarningsPage";
 import DriverSettingsPage from "./pages/DriverSettingsPage";
 import TestMap from "./pages/TestMap";
 import UserRideHistory from "./pages/UserRideHistory";
+import { SnackbarProvider } from "./components/SnackbarProvider";
 
 /* ─────── themes ─────── */
 const gtaDarkTheme = createTheme({
@@ -132,7 +133,9 @@ function AppShell() {
 export default function App() {
   return (
     <ArgonControllerProvider>
-      <AppShell />
+      <SnackbarProvider>
+        <AppShell />
+      </SnackbarProvider>
     </ArgonControllerProvider>
   );
 }

--- a/src/components/SnackbarProvider.js
+++ b/src/components/SnackbarProvider.js
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { Snackbar, Alert } from '@mui/material';
+
+const SnackbarContext = createContext(null);
+
+export function SnackbarProvider({ children }) {
+  const [snackbar, setSnackbar] = useState({
+    open: false,
+    message: '',
+    severity: 'info',
+    autoHideDuration: 4000,
+  });
+
+  const showSnackbar = useCallback((message, severity = 'info', autoHideDuration = 4000) => {
+    setSnackbar({ open: true, message, severity, autoHideDuration });
+  }, []);
+
+  const handleClose = (_event, reason) => {
+    if (reason === 'clickaway') return;
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  return (
+    <SnackbarContext.Provider value={showSnackbar}>
+      {children}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={snackbar.autoHideDuration}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </SnackbarContext.Provider>
+  );
+}
+
+export function useSnackbar() {
+  const context = useContext(SnackbarContext);
+  if (context === null) {
+    throw new Error('useSnackbar must be used within a SnackbarProvider');
+  }
+  return context;
+}
+

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -20,9 +20,11 @@ import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
 import SupportAgentIcon from '@mui/icons-material/SupportAgent';
 import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 import logger from '../logger';
+import { useSnackbar } from '../components/SnackbarProvider';
 
 export default function HomePage() {
   const navigate = useNavigate();
+  const showSnackbar = useSnackbar();
 
   const [pickup, setPickup] = useState('');
   const [dropoff, setDropoff] = useState('');
@@ -31,12 +33,12 @@ export default function HomePage() {
 
   const handleEstimate = () => {
     if (!pickup || !dropoff || pickup === dropoff) {
-      alert('Please select valid locations.');
+      showSnackbar('Please select valid locations.', 'warning', 4000);
       return;
     }
     const summary = getLocalTaxiRate(pickup, dropoff, 1);
     if (!summary) {
-      alert('No rate found for this route.');
+      showSnackbar('No rate found for this route.', 'warning', 4000);
       setFareInfo(null);
       return;
     }
@@ -45,7 +47,7 @@ export default function HomePage() {
 
   const handleBookRide = () => {
     if (!fareInfo) {
-      alert('Please estimate your fare first.');
+      showSnackbar('Please estimate your fare first.', 'warning', 4000);
       return;
     }
     setBookingBusy(true);
@@ -61,7 +63,7 @@ export default function HomePage() {
       navigate(`/ridesharing/review/${rideId}`);
     } catch (err) {
       logger.error('🔥 handleBookRide error:', err);
-      alert('Could not create ride. Please try again.');
+      showSnackbar('Could not create ride. Please try again.', 'error', 6000);
     } finally {
       setBookingBusy(false);
     }

--- a/src/pages/RideConfirmedPage.js
+++ b/src/pages/RideConfirmedPage.js
@@ -9,6 +9,7 @@ import {
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { loadStripe } from '@stripe/stripe-js';
 import logger from '../logger';
+import { useSnackbar } from '../components/SnackbarProvider';
 
 /* ------------- Stripe initialisation (CRA uses process.env) ------------- */
 const stripePromise = loadStripe(
@@ -27,6 +28,7 @@ export default function RideConfirmedPage() {
   const navigate   = useNavigate();
   const location   = useLocation();
   const { rideId } = useParams();
+  const showSnackbar = useSnackbar();
 
   /* ---------- Retrieve ride from navigation state or localStorage ---------- */
   const [ride, setRide] = useState(() => location.state?.ride || readRide(rideId));
@@ -79,7 +81,7 @@ export default function RideConfirmedPage() {
       if (error) throw error;
     } catch (err) {
       logger.error('Stripe Checkout error', err);
-      alert('Unable to start payment. Please try again.');
+      showSnackbar('Unable to start payment. Please try again.', 'error', 6000);
     } finally {
       setPaying(false);
     }

--- a/src/pages/RideRequestPage.js
+++ b/src/pages/RideRequestPage.js
@@ -1,28 +1,19 @@
 // src/pages/RideRequestPage.js
 
 import React, { useState } from "react";
-import {
-  Box,
-  Button,
-  MenuItem,
-  TextField,
-  Typography,
-  Paper,
-} from "@mui/material";
+import { Box, Button, MenuItem, TextField, Typography, Paper } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { taxiRates } from "../data/taxiRates";
 import { locationCoords } from "../data/locationCoords";
 import { getLocalTaxiRate } from "../lib/getLocalTaxiRate";
 import { createRideRequest } from "../lib/createRideRequest";
-import { locationCoords } from "../data/locationCoords";
-
 import logger from "../logger";
-
-import { createRideRequest } from "../lib/createRideRequest";
+import { useSnackbar } from "../components/SnackbarProvider";
 
 
 export default function RideRequestPage() {
   const navigate = useNavigate();
+  const showSnackbar = useSnackbar();
   const [pickup, setPickup] = useState("");
   const [dropoff, setDropoff] = useState("");
   const [passengerCount, setPassengerCount] = useState(1);
@@ -46,7 +37,7 @@ export default function RideRequestPage() {
 
   const handleSubmit = () => {
     if (!pickup || !dropoff || pickup === dropoff) {
-      alert("Please select valid locations.");
+      showSnackbar("Please select valid locations.", "warning", 4000);
       return;
     }
 
@@ -66,7 +57,7 @@ export default function RideRequestPage() {
       navigate(`/ridesharing/review/${rideId}`);
     } catch (error) {
       logger.error("Failed to preview ride:", error);
-      alert("Could not continue to review page.");
+      showSnackbar("Could not continue to review page.", "error", 6000);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- add SnackbarProvider and useSnackbar hook for global MUI alerts
- refactor home and ride pages to use Snackbar instead of `alert`

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden from registry)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689455e9b2208329b7a8f536b4521c5c