### PR TITLE
Add basic chat page and components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ import SignInPage from "./pages/SignInPage";
 import SignUpPage from "./pages/SignUpPage";
 import PrivateRoute from "./components/PrivateRoute";
 import { SnackbarProvider } from "./components/SnackbarProvider";
+import ChatPage from "./pages/ChatPage";
 
 
 /* ─────── themes ─────── */
@@ -125,6 +126,7 @@ function AppShell() {
         {/* Misc */}
         <Route path="/profile/rides" element={<PrivateRoute><UserRideHistory /></PrivateRoute>} />
         <Route path="/test-map" element={<TestMap />} />
+        <Route path="/chat" element={<ChatPage />} />
 
         {/* 404 */}
         <Route

--- a/src/__tests__/ChatPage.test.js
+++ b/src/__tests__/ChatPage.test.js
@@ -1,0 +1,10 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ChatPage from '../pages/ChatPage';
+
+test('user can send a message', () => {
+  render(<ChatPage />);
+  const input = screen.getByPlaceholderText(/type a message/i);
+  fireEvent.change(input, { target: { value: 'Hello' } });
+  fireEvent.click(screen.getByText(/send/i));
+  expect(screen.getByText('Hello')).toBeInTheDocument();
+});

--- a/src/components/ChatMessage.js
+++ b/src/components/ChatMessage.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+export default function ChatMessage({ message, sender }) {
+  return (
+    <Box sx={{ mb: 1, textAlign: sender === 'user' ? 'right' : 'left' }}>
+      <Typography variant="body2" color="text.secondary">
+        {sender}
+      </Typography>
+      <Box
+        sx={{
+          display: 'inline-block',
+          px: 1.5,
+          py: 1,
+          borderRadius: 1,
+          bgcolor: sender === 'user' ? 'primary.main' : 'grey.300',
+          color: sender === 'user' ? 'primary.contrastText' : 'text.primary',
+        }}
+      >
+        {message}
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/ChatPage.js
+++ b/src/pages/ChatPage.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Container, Box, TextField, Button, Typography } from '@mui/material';
+import ChatMessage from '../components/ChatMessage';
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text) return;
+    setMessages((prev) => [...prev, { id: Date.now(), text, sender: 'user' }]);
+    setInput('');
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Chat
+      </Typography>
+      <Box
+        sx={{
+          height: '60vh',
+          border: '1px solid',
+          borderColor: 'divider',
+          p: 2,
+          mb: 2,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {messages.map((m) => (
+          <ChatMessage key={m.id} message={m.text} sender={m.sender} />
+        ))}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <TextField
+          fullWidth
+          placeholder="Type a message..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSend();
+          }}
+        />
+        <Button variant="contained" onClick={handleSend}>
+          Send
+        </Button>
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ChatMessage` component and `ChatPage` with message input and list
- register `/chat` route in App
- include simple test verifying messages render after send

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ajv)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e5704d883298dd9501881a3a9f7